### PR TITLE
Remove Dlog_file

### DIFF
--- a/src/main/java/de/codecentric/jmeter/JMeterPluginsMojo.java
+++ b/src/main/java/de/codecentric/jmeter/JMeterPluginsMojo.java
@@ -114,7 +114,7 @@ public class JMeterPluginsMojo extends AbstractMojo {
                                 element(name("executable"), "java"),
                                 element(name("workingDirectory"), binDir.getAbsolutePath()),
                                 element(name("arguments"),
-                                        element(name("argument"), "-Dlog_file="),
+                                        //element(name("argument"), "-Dlog_file="),
                                         element(name("argument"), "-classpath"),
                                         element(name("argument"),
                                                 libDir.getAbsolutePath() + File.separator + "*" +

--- a/src/main/java/de/codecentric/jmeter/JMeterPluginsMojo.java
+++ b/src/main/java/de/codecentric/jmeter/JMeterPluginsMojo.java
@@ -114,7 +114,6 @@ public class JMeterPluginsMojo extends AbstractMojo {
                                 element(name("executable"), "java"),
                                 element(name("workingDirectory"), binDir.getAbsolutePath()),
                                 element(name("arguments"),
-                                        //element(name("argument"), "-Dlog_file="),
                                         element(name("argument"), "-classpath"),
                                         element(name("argument"),
                                                 libDir.getAbsolutePath() + File.separator + "*" +


### PR DESCRIPTION
Previously, Dlog_file was specified as an empty argument to the CMDRunner which resulted in an IOException when running the create-graph goal on the command line. It wasn't a big deal, as the maven goal simply continued running, with the log redirected to standard output. However, this resulted in quite a lot of "clutter" on the command line, so although the IOException wasn't functionally relevant, it was quite an annoyance.
